### PR TITLE
Remove application declaration in lib

### DIFF
--- a/vertical-stepper-form/src/main/AndroidManifest.xml
+++ b/vertical-stepper-form/src/main/AndroidManifest.xml
@@ -1,11 +1,2 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="ernestoyaquello.com.verticalstepperform">
-
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true">
-
-    </application>
-
-</manifest>
+    package="ernestoyaquello.com.verticalstepperform" />

--- a/vertical-stepper-form/src/main/res/values/strings.xml
+++ b/vertical-stepper-form/src/main/res/values/strings.xml
@@ -1,5 +1,4 @@
 <resources>
-    <string name="app_name">Vertical Stepper Form</string>
     <string name="vertical_form_stepper_form_continue">Continue</string>
     <string name="vertical_form_stepper_form_discard_question">Discard data?</string>
     <string name="vertical_form_stepper_form_info_will_be_lost">All the information you have given will be lost</string>


### PR DESCRIPTION
Remove Android application declaration in library which caused an unecessary manifest merge in the final app if the following values were different:

``` xml
<application
        android:allowBackup="true"
        android:label="@string/app_name"
        android:supportsRtl="true"
```
